### PR TITLE
Add Podman CLI check

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -285,9 +285,9 @@ Here is a course for learning (or brushing up) on working from the linux command
         kubectl version
         ```
 
-=== "CRC (MiniShift)"
+=== "OpenShift Local"
 
-    Make sure CRC is installed. Check out the [CRC Page](https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/1.0/html/getting_started_guide/getting-started-with-codeready-containers_gsg) 
+    Make sure OpenShift Local is installed. Check out the [OpenShift Local](https://docs.redhat.com/en/documentation/red_hat_openshift_local/2.44/html/getting_started_guide/index){target="_blank"} Page.
 
     ** Setup CRC **
     ```

--- a/docs/scripts/system-check.sh
+++ b/docs/scripts/system-check.sh
@@ -53,7 +53,18 @@ else
     printf 'For Mac: https://docs.docker.com/docker-for-mac/install/ \n'
     printf 'For Linux Users: https://docs.docker.com/engine/install/ubuntu/ \n'
     printf 'For Windows: https://docs.docker.com/docker-for-windows/install/ \n \n'
+fi
 
+if hash podman 2>/dev/null
+then
+    printf '\xE2\x9C\x85 Podman CLI \n'
+else
+    printf '\xE2\x9D\x8C Podman CLI \n \n'
+
+    printf 'Download the Podman CLI using the links below: \n'
+    printf 'For Mac: https://podman.io/docs/installation#macos \n'
+    printf 'For Linux Users: https://podman.io/docs/installation#linux-distributions \n'
+    printf 'For Windows: https://podman.io/docs/installation#windows \n \n'
 fi
 
 if hash kubectl 2>/dev/null
@@ -93,5 +104,7 @@ else
     printf '\xE2\x9D\x8C Argo CLI \n \n'
 
     printf 'Download the Argo CLI using the links below: \n'
-    printf 'For All Users: https://argoproj.github.io/argo-cd/cli_installation/ \n \n'
+    printf 'For All Users: https://argo-cd.readthedocs.io/en/stable/cli_installation/ \n \n'
 fi
+
+printf " \nInstall either Docker or Podman, it's not necessary to install both\n"


### PR DESCRIPTION
Add a check for Podman CLI along with a message notifying that either Docker or Podman can be installed, it's not necessary to install both to complete the Cloud Native Bootcamp